### PR TITLE
Change implicit method to seglist method for optimizing

### DIFF
--- a/mm.c
+++ b/mm.c
@@ -1,24 +1,3 @@
-/*
- * mm-naive.c - The fastest, least memory-efficient malloc package.
- *
- * In this naive approach, a block is allocated by simply incrementing
- * the brk pointer.  A block is pure payload. There are no headers or
- * footers.  Blocks are never coalesced or reused. Realloc is
- * implemented directly using mm_malloc and mm_free.
- *
- * NOTE TO STUDENTS: Replace this header comment with your own header
- * comment that gives a high level description of your solution.
- * ----------
- * mm-naive.c - 가장 빠르고 메모리 효율이 가장 낮은 malloc 패키지입니다.
- *
- * 이 순진한 접근 방식에서는 단순히 brk 포인터를 증가시켜 블록을 할당합니다.
- * 블록은 순수한 페이로드입니다. 헤더나 푸터가 없습니다.
- * 블록은 합쳐지거나 재사용되지 않습니다.
- * 재할당은 mm_malloc과 mm_free를 사용해 직접 구현됩니다.
- *
- * 학생 참고 사항: 이 헤더 코멘트는 솔루션에 대한 높은 수준의
- * 설명을 제공하는 자신만의 헤더 코멘트로 대체하세요.
- */
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -28,10 +7,6 @@
 #include "mm.h"
 #include "memlib.h"
 
-/*********************************************************
- * NOTE TO STUDENTS: Before you do anything else, please
- * provide your team information in the following struct.
- ********************************************************/
 team_t team = {
     /* Team name */
     "Classroom4_Week05_Team2_malloc-lab",
@@ -58,6 +33,7 @@ team_t team = {
 
 /*주어진 두 값 중 큰 값을 반환하는 매크로*/
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
+
 /*메모리 블록의 크기와 할당 비트를 결합하여 헤더 및 풋터에 저장할 값을 반환하는 매크로*/
 #define PACK(size, alloc) ((size) | (alloc))
 
@@ -72,7 +48,7 @@ p가 가리키는 메모리를 unsigned int로 캐스팅한 뒤 해당 위치에
 #define GET_ALLOC(p) (GET(p) & 0x1)
 
 /*주어진 블록 포인터 bp에 대한 헤더 주소를 반환, 주소 bp에서 워드 크기만큼 뺀 주소를 반환
-헤더 주소에서 해당 블록의 크기를 구한 뒤 더블 워드 크기를 배서 풋터의 주소를 반환*/
+헤더 주소에서 해당 블록의 크기를 구한 뒤 더블 워드 크기를 빼서 풋터의 주소를 반환*/
 #define HDRP(bp) ((char *)(bp)-WSIZE)
 #define FTRP(bp) ((char *)(bp) + GET_SIZE(HDRP(bp)) - DSIZE)
 
@@ -81,177 +57,126 @@ p가 가리키는 메모리를 unsigned int로 캐스팅한 뒤 해당 위치에
 #define NEXT_BLKP(bp) ((char *)(bp) + GET_SIZE(((char *)(bp)-WSIZE)))
 #define PREV_BLKP(bp) ((char *)(bp)-GET_SIZE(((char *)(bp)-DSIZE)))
 
-static void *coalesce(void *bp);           // 주변의 가용 블록을 병합하여 하나의 블록으로 만드는 함수를 선언
-static void *extend_heap(size_t words);    // 힙을 확장하는 함수를 선언
-static void *heap_listp;                   // 가용 리스트의 시작을 나타내는 포인터
-int mm_init(void);                         // 메모리 할당 시스템을 초기화하는 함수를 선언
-static void *find_fit(size_t asize);       // 요청된 크기에 맞는 가용 블록을 탐색하는 함수를 선언
-static void place(void *bp, size_t aszie); // 할당된 메모리 블록을 가용 리스트에서 제거하고 요청된 크기로 분할하는 함수를 선언
-void *mm_malloc(size_t size);              // 주어진 크기의 메모리 블록을 할당하는 함수를 선언
-void mm_free(void *ptr);                   // 이전에 할당된 메모리 블록을 해제하는 함수를 선언
-void *mm_realloc(void *ptr, size_t size);  // 이전에 할당된 메모리 블록의 크기를 조정하거나 새로운 위치로 메모리를 이동하는 함수를 선언
-static void *find_nextp;                   // 다음 가용 블록을 탐색하기 위한 포인터 (next_fit)
+// ----------
+// 가정: 최대 12개의 사이즈 클래스가 있음
+#define MAX_SIZE_CLASS 12
 
-static void *coalesce(void *bp)
-{
-    size_t prev_alloc = GET_ALLOC(FTRP(PREV_BLKP(bp)));
-    size_t next_alloc = GET_ALLOC(HDRP(NEXT_BLKP(bp)));
-    size_t size = GET_SIZE(HDRP(bp));
+// 다음 가용 블록의 포인터를 가져오는 매크로
+#define GET_NEXT_FREEBLK(bp) (*(char **)(bp + WSIZE))
 
-    if (prev_alloc && next_alloc) /* Case 1 */
-    {
-        return bp;
-    }
+// 이전 가용 블록의 포인터를 가져오는 매크로
+#define GET_PREV_FREEBLK(bp) (*(char **)(bp))
 
-    if (prev_alloc && !next_alloc) /* Case 2 */
-    {
-        size += GET_SIZE(HDRP(NEXT_BLKP(bp)));
-        PUT(HDRP(bp), PACK(size, 0));
-        PUT(FTRP(bp), PACK(size, 0));
-    }
-    else if (!prev_alloc && next_alloc) /* Case 3 */
-    {
-        size += GET_SIZE(HDRP(PREV_BLKP(bp)));
-        PUT(FTRP(bp), PACK(size, 0));
-        PUT(HDRP(PREV_BLKP(bp)), PACK(size, 0));
-        bp = PREV_BLKP(bp);
-    }
-    else /* Case 4 */
-    {
-        size += GET_SIZE(HDRP(PREV_BLKP(bp))) +
-                GET_SIZE(FTRP(NEXT_BLKP(bp)));
-        PUT(HDRP(PREV_BLKP(bp)), PACK(size, 0));
-        PUT(FTRP(NEXT_BLKP(bp)), PACK(size, 0));
-        bp = PREV_BLKP(bp);
-    }
-    find_nextp = bp;
-    return bp;
-}
+// 다음 가용 블록의 포인터를 설정하는 매크로
+#define SET_NEXT_FREEBLK(bp, next_bp) (GET_NEXT_FREEBLK(bp) = next_bp)
 
-static void *extend_heap(size_t words)
-{
-    char *bp;
-    size_t size;
+// 이전 가용 블록의 포인터를 설정하는 매크로
+#define SET_PREV_FREEBLK(bp, prev_bp) (GET_PREV_FREEBLK(bp) = prev_bp)
 
-    // 확장할 크기를 정렬 요구 사항에 맞게 조정
-    size = (words % 2) ? (words + 1) * WSIZE : words * WSIZE;
+static void *heap_listp;                    // 가용 리스트의 시작을 나타내는 포인터
+static void *seg_free_list[MAX_SIZE_CLASS]; // 각 사이즈 클래스별 free list의 헤드를 저장하는 배열
+// 사이즈 클래스 분류 기준 예시 (간단화된 버전)
+static int size_classes[MAX_SIZE_CLASS] = {4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
 
-    if ((long)(bp = mem_sbrk(size)) == -1)
-        return NULL;
+// 요청된 크기에 맞는 가장 적합한 free block을 찾는 함수
+// Seglist를 순회하여 적절한 크기의 블록을 찾음
+static void *find_fit(size_t size);
 
-    // 새로 확장된 영역의 프리 블록 헤더와 푸터, 그리고 새 에필로그 헤더 초기화
-    PUT(HDRP(bp), PACK(size, 0));         // 프리 블록 헤더
-    PUT(FTRP(bp), PACK(size, 0));         // 프리 블록 푸터
-    PUT(HDRP(NEXT_BLKP(bp)), PACK(0, 1)); // 새 에필로그 헤더
+// 할당된 블록에 메모리를 할당
+// 필요하다면 남은 부분을 분할하여 free list에 추가
+static void place(void *bp, size_t asize);
 
-    // 인접한 프리 블록과의 병합을 시도하여 메모리 단편화 감소
-    // 코얼레스 (코알라, 코머시기)
-    return coalesce(bp);
-}
+static int find_class_index(size_t size);
+
+// Free block을 적절한 seglist에 삽입하는 함수
+// Free 또는 Coalesce 과정에서 사용
+static void add_block_to_seglist(void *bp, size_t size);
+
+// Free list에서 특정 블록을 제거하는 함수. 할당 과정에서 사용
+static void remove_block_from_seglist(void *bp);
+
+static void *extend_heap(size_t words);
+
+// 인접한 free block을 병합하는 기존 함수를 seglist 방식에 맞게 조정
+// 병합된 블록을 적절한 seglist에 재배치
+static void *coalesce(void *bp);
 
 /*
  * mm_init - initialize the malloc package.
  */
 int mm_init(void)
 {
-    if ((heap_listp = mem_sbrk(4 * WSIZE)) == (void *)-1) // 초기 힙 메모리를 할당
-        return -1;
+    // 1. seg_free_list 초기화
+    for (int i = 0; i < MAX_SIZE_CLASS; i++)
+    {
+        seg_free_list[i] = NULL;
+    }
 
-    PUT(heap_listp, 0);                            // 힙의 시작 부분에 0을 저장하여 패딩으로 사용
-    PUT(heap_listp + (1 * WSIZE), PACK(DSIZE, 1)); // 프롤로그 블럭의 헤더에 할당된 상태로 표시하기 위해 사이즈와 할당 비트를 설정하여 값을 저장
-    PUT(heap_listp + (2 * WSIZE), PACK(DSIZE, 1)); // 프롤로그 블록의 풋터에도 마찬가지로 사이즈와 할당 비트를 설정하여 값을 저장
-    PUT(heap_listp + (3 * WSIZE), PACK(0, 1));     // 에필로그 블록의 헤더를 설정하여 힙의 끝을 나타내는 데 사용
-    heap_listp += (2 * WSIZE);                     // 프롤로그 블록 다음의 첫 번째 바이트를 가리키도록 포인터 조정
-    find_nextp = heap_listp;                       // nextfit을 위한 변수
-
-    if (extend_heap(CHUNKSIZE / WSIZE) == NULL) // 초기 힙을 확장하여 충분한 양의 메모리가 사용 가능하도록 chunksize를 단어 단위로 변환하여 힙 확장
+    // 2. 초기 힙 영역 설정
+    if ((heap_listp = mem_sbrk(4 * WSIZE)) == (void *)-1)
+    {
         return -1;
+    }
+
+    PUT(heap_listp, 0);                            // 패딩 블록
+    PUT(heap_listp + (1 * WSIZE), PACK(DSIZE, 1)); // 프롤로그 헤더
+    PUT(heap_listp + (2 * WSIZE), PACK(DSIZE, 1)); // 프롤로그 풋터
+    PUT(heap_listp + (3 * WSIZE), PACK(0, 1));     // 에필로그 헤더
+
+    heap_listp += (2 * WSIZE);
+
+    // 3. 초기 가용 블록 생성을 위한 힙 확장
+    if (extend_heap(CHUNKSIZE / WSIZE) == NULL)
+    {
+        return -1;
+    }
 
     return 0;
 }
 
-static void *find_fit(size_t asize)
-{
-    /* Next-fit search */
-    void *bp;
-    bp = find_nextp;
-    // 현재 블록이 에필로그 블록이 아닌 동안 계속 순회, 블록의 헤더 크기가 0보다 크지 않으면 에필로그 블럭
-    for (; GET_SIZE(HDRP(find_nextp)) > 0; find_nextp = NEXT_BLKP(find_nextp))
-    {
-        // 가용 블럭의 헤더가 할당되어 있지 않고 요청된 크기보다 크거나 같은 경우 해당 가용 블록을 반환
-        if (!GET_ALLOC(HDRP(find_nextp)) && (asize <= GET_SIZE(HDRP(find_nextp))))
-        {
-            return find_nextp;
-        }
-    }
-    // 위의 for루프에서 가용 블럭을 찾지 못한 경우, 다시 순회
-    for (find_nextp = heap_listp; find_nextp != bp; find_nextp = NEXT_BLKP(find_nextp))
-    { // 이전에 탐색했던 find_nextp 위치에서부터 다시 가용 블록을 찾아서 반환
-        if (!GET_ALLOC(HDRP(find_nextp)) && (asize <= GET_SIZE(HDRP(find_nextp))))
-        {
-            return find_nextp;
-        }
-    }
-
-    return NULL;
-}
-
-static void place(void *bp, size_t asize)
-{
-    size_t csize = GET_SIZE(HDRP(bp)); // 현재 블록의 크기를 알아냄
-
-    // 남은 공간이 충분히 클 경우, 즉 요청한 크기(asize)와 현재 크기(csize)의 차이가
-    // 두 배의 더블 사이즈(DSIZE)보다 크거나 같으면 블록을 나눔
-    if ((csize - asize) >= (2 * DSIZE))
-    {
-        PUT(HDRP(bp), PACK(asize, 1));         // 사용할 블록의 헤더에 크기와 할당된 상태 저장
-        PUT(FTRP(bp), PACK(asize, 1));         // 사용할 블록의 푸터에도 똑같이 저장
-        bp = NEXT_BLKP(bp);                    // 나머지 블록으로 포인터 이동
-        PUT(HDRP(bp), PACK(csize - asize, 0)); // 나머지 블록의 헤더에 크기와 빈 상태 저장
-        PUT(FTRP(bp), PACK(csize - asize, 0)); // 나머지 블록의 푸터에도 똑같이 저장
-    }
-    else // 남은 공간이 충분히 크지 않으면 현재 블록 전체 사용
-    {
-        PUT(HDRP(bp), PACK(csize, 1)); // 현재 블록의 헤더에 크기와 할당된 상태 저장
-        PUT(FTRP(bp), PACK(csize, 1)); // 현재 블록의 푸터에도 똑같이 저장
-    }
-}
-
 /*
  * mm_malloc - Allocate a block by incrementing the brk pointer.
- *     Always allocate a block whose size is a multiple of the alignment.
+ * Always allocate a block whose size is a multiple of the alignment.
  */
-
+// 메모리 블록을 할당하는 함수
 void *mm_malloc(size_t size)
 {
-    size_t asize;      /* Adjusted block size */
-    size_t extendsize; /* Amount to extend heap if no fit */
+    size_t asize;      // 조정된 블록 크기
+    size_t extendsize; // 필요한 경우 힙을 확장할 크기
     char *bp;
 
-    /* Ignore spurious requests */
+    // 요청된 크기가 0이면 할당하지 않음
     if (size == 0)
-        return NULL;
-
-    /* Adjust block size to include overhead and alignment reqs. */
-    if (size <= DSIZE)
-        asize = 2 * DSIZE;
-    else
-        asize = DSIZE * ((size + (DSIZE) + (DSIZE - 1)) / DSIZE);
-
-    /* Search the free list for a fit */
-    if ((bp = find_fit(asize)) != NULL)
     {
-        place(bp, asize);
+        return NULL;
+    }
+
+    // 블록 크기를 조정 (예: 헤더와 푸터 크기 포함)
+    if (size <= DSIZE)
+    {
+        asize = 2 * DSIZE;
+    }
+    else
+    {
+        asize = DSIZE * ((size + (DSIZE) + (DSIZE - 1)) / DSIZE);
+    }
+
+    // 적절한 사이즈 클래스에서 블록 탐색
+    if ((bp = find_fit(asize)) != NULL)
+    {                     // 적합한 블록 찾음
+        place(bp, asize); // 블록 할당
         return bp;
     }
 
-    /* No fit found. Get more memory and place the block */
+    // 적합한 블록을 찾지 못한 경우, 힙을 확장하고 새로운 블록 할당
     extendsize = MAX(asize, CHUNKSIZE);
 
     if ((bp = extend_heap(extendsize / WSIZE)) == NULL)
+    {
         return NULL;
+    }
 
-    place(bp, asize);
+    place(bp, asize); // 블록 할당
 
     return bp;
 }
@@ -294,4 +219,173 @@ void *mm_realloc(void *ptr, size_t size)
     mm_free(oldptr);
 
     return newptr;
+}
+
+// 요청된 크기에 맞는 가장 적합한 free block을 찾는 함수
+// Seglist를 순회하여 적절한 크기의 블록을 찾음
+// 사이즈 클래스별로 분리된 리스트에서 적합한 블록을 찾는 함수
+static void *find_fit(size_t asize)
+{
+    void *bp;
+
+    // 요청 인덱스로 크기에 맞는 사이즈 클래스를 찾아 해당 클래스부터 탐색 시작
+    for (int classIndex = find_class_index(asize); classIndex < MAX_SIZE_CLASS; classIndex++)
+    {
+        for (bp = seg_free_list[classIndex]; bp != NULL; bp = GET_NEXT_FREEBLK(bp))
+        {
+            if (asize <= GET_SIZE(HDRP(bp)))
+            {
+                return bp; // 적합한 블록을 찾았으면 반환
+            }
+        }
+    }
+
+    return NULL; // 적합한 블록을 찾지 못함
+}
+
+// 할당된 블록에 메모리를 할당
+// 필요하다면 남은 부분을 분할하여 free list에 추가
+static void place(void *bp, size_t asize)
+{
+    size_t csize = GET_SIZE(HDRP(bp)); // 현재 블록의 크기를 알아냄
+
+    // 남은 공간이 충분히 클 경우, 즉 요청한 크기(asize)와 현재 크기(csize)의 차이가
+    // 두 배의 더블 사이즈(DSIZE)보다 크거나 같으면 블록을 나눔
+    if ((csize - asize) >= (2 * DSIZE))
+    {
+        PUT(HDRP(bp), PACK(asize, 1));           // 사용할 블록의 헤더에 크기와 할당된 상태 저장
+        PUT(FTRP(bp), PACK(asize, 1));           // 사용할 블록의 푸터에도 똑같이 저장
+        bp = NEXT_BLKP(bp);                      // 나머지 블록으로 포인터 이동
+        PUT(HDRP(bp), PACK(csize - asize, 0));   // 나머지 블록의 헤더에 크기와 빈 상태 저장
+        PUT(FTRP(bp), PACK(csize - asize, 0));   // 나머지 블록의 푸터에도 똑같이 저장
+        add_block_to_seglist(bp, csize - asize); // 남은 부분을 적절한 사이즈 클래스에 추가
+    }
+    else // 남은 공간이 충분히 크지 않으면 현재 블록 전체 사용
+    {
+        PUT(HDRP(bp), PACK(csize, 1)); // 현재 블록의 헤더에 크기와 할당된 상태 저장
+        PUT(FTRP(bp), PACK(csize, 1)); // 현재 블록의 푸터에도 똑같이 저장
+    }
+}
+
+static void *extend_heap(size_t words)
+{
+    char *bp;
+    size_t size;
+
+    // 확장할 크기를 정렬 요구 사항에 맞게 조정
+    size = (words % 2) ? (words + 1) * WSIZE : words * WSIZE;
+
+    if ((long)(bp = mem_sbrk(size)) == -1)
+    {
+        return NULL;
+    }
+
+    // 새로 확장된 영역의 프리 블록 헤더와 푸터, 그리고 새 에필로그 헤더 초기화
+    PUT(HDRP(bp), PACK(size, 0));         // 프리 블록 헤더
+    PUT(FTRP(bp), PACK(size, 0));         // 프리 블록 푸터
+    PUT(HDRP(NEXT_BLKP(bp)), PACK(0, 1)); // 새 에필로그 헤더
+
+    // 인접한 프리 블록과의 병합을 시도하여 메모리 단편화 감소
+    bp = coalesce(bp);
+
+    // 병합된 가용 블록을 적절한 사이즈 클래스의 segregated free list에 추가
+    add_block_to_seglist(bp, size);
+
+    return bp;
+}
+
+// 인접한 free block을 병합하는 기존 함수를 seglist 방식에 맞게 조정
+// 병합된 블록을 적절한 seglist에 재배치
+static void *coalesce(void *bp)
+{
+    size_t prev_alloc = GET_ALLOC(FTRP(PREV_BLKP(bp)));
+    size_t next_alloc = GET_ALLOC(HDRP(NEXT_BLKP(bp)));
+    size_t size = GET_SIZE(HDRP(bp));
+
+    if (prev_alloc && !next_alloc)
+    { // 다음 블록만 가용
+        remove_block_from_seglist(NEXT_BLKP(bp));
+        size += GET_SIZE(HDRP(NEXT_BLKP(bp)));
+        PUT(HDRP(bp), PACK(size, 0));
+        PUT(FTRP(bp), PACK(size, 0));
+    }
+    else if (!prev_alloc && next_alloc)
+    { // 이전 블록만 가용
+        remove_block_from_seglist(PREV_BLKP(bp));
+        size += GET_SIZE(HDRP(PREV_BLKP(bp)));
+        PUT(FTRP(bp), PACK(size, 0));
+        PUT(HDRP(PREV_BLKP(bp)), PACK(size, 0));
+        bp = PREV_BLKP(bp);
+    }
+    else if (!prev_alloc && !next_alloc)
+    { // 이전과 다음 블록 모두 가용
+        remove_block_from_seglist(PREV_BLKP(bp));
+        remove_block_from_seglist(NEXT_BLKP(bp));
+        size += GET_SIZE(HDRP(PREV_BLKP(bp))) + GET_SIZE(HDRP(NEXT_BLKP(bp)));
+        PUT(HDRP(PREV_BLKP(bp)), PACK(size, 0));
+        PUT(FTRP(NEXT_BLKP(bp)), PACK(size, 0));
+        bp = PREV_BLKP(bp);
+    }
+
+    // 병합된 블록을 적절한 사이즈 클래스의 리스트에 추가
+    add_block_to_seglist(bp, size);
+    return bp;
+}
+
+// Free block을 적절한 seglist에 삽입하는 함수. Free 또는 Coalesce 과정에서 사용
+// 메모리 블록을 적절한 사이즈 클래스의 리스트에 추가하는 함수
+static void add_block_to_seglist(void *bp, size_t size)
+{
+    // 1. 적절한 사이즈 클래스 찾기
+    int class_index = find_class_index(size);
+
+    // 2. 현재 블록을 리스트의 첫 번째 위치에 추가
+    // 만약 해당 사이즈 클래스에 다른 블록이 이미 있다면, 그 블록을 현재 블록 다음으로 설정
+    if (seg_free_list[class_index] != NULL)
+    {
+        SET_NEXT_FREEBLK(bp, seg_free_list[class_index]);
+        SET_PREV_FREEBLK(seg_free_list[class_index], bp);
+    }
+
+    // 3. 새로운 블록을 리스트의 시작점으로 설정
+    seg_free_list[class_index] = bp;
+    SET_PREV_FREEBLK(bp, NULL);
+}
+
+// Free list에서 특정 블록을 제거하는 함수. 할당 과정에서 사용
+// 메모리 블록을 사이즈 클래스의 리스트에서 제거하는 함수
+static void remove_block_from_seglist(void *bp)
+{
+    int class_index = find_class_index(GET_SIZE(HDRP(bp)));
+
+    // 만약 이 블록이 리스트의 첫 번째 블록이라면
+    if (bp == seg_free_list[class_index])
+    {
+        seg_free_list[class_index] = GET_NEXT_FREEBLK(bp);
+    }
+
+    // 이전 블록과 다음 블록을 연결
+    if (GET_PREV_FREEBLK(bp) != NULL)
+    {
+        SET_NEXT_FREEBLK(GET_PREV_FREEBLK(bp), GET_NEXT_FREEBLK(bp));
+    }
+
+    if (GET_NEXT_FREEBLK(bp) != NULL)
+    {
+        SET_PREV_FREEBLK(GET_NEXT_FREEBLK(bp), GET_PREV_FREEBLK(bp));
+    }
+}
+
+// 주어진 크기에 맞는 사이즈 클래스 인덱스를 찾는 함수
+static int find_class_index(size_t size)
+{
+    for (int i = 0; i < MAX_SIZE_CLASS; i++)
+    {
+        if (size <= size_classes[i])
+        {
+            return i; // 주어진 크기가 현재 사이즈 클래스 범위에 들어오면 인덱스 반환
+        }
+    }
+
+    return MAX_SIZE_CLASS - 1; // 가장 큰 사이즈 클래스 반환
 }

--- a/mm.c
+++ b/mm.c
@@ -1,8 +1,8 @@
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
-#include <unistd.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "mm.h"
 #include "memlib.h"
@@ -106,6 +106,8 @@ static void *coalesce(void *bp);
  */
 int mm_init(void)
 {
+    printf("[mm_init] 함수 시작\n");
+
     // 1. seg_free_list 초기화
     for (int i = 0; i < MAX_SIZE_CLASS; i++)
     {
@@ -115,6 +117,8 @@ int mm_init(void)
     // 2. 초기 힙 영역 설정
     if ((heap_listp = mem_sbrk(4 * WSIZE)) == (void *)-1)
     {
+        printf("[mm_init] 함수 종료, ERROR: (heap_listp = mem_sbrk(4 * WSIZE)) == (void *)-1\n");
+
         return -1;
     }
 
@@ -128,8 +132,12 @@ int mm_init(void)
     // 3. 초기 가용 블록 생성을 위한 힙 확장
     if (extend_heap(CHUNKSIZE / WSIZE) == NULL)
     {
+        printf("[mm_init] 함수 종료, ERROR: extend_heap(CHUNKSIZE / WSIZE) == NULL\n");
+
         return -1;
     }
+
+    printf("[mm_init] 함수 종료\n");
 
     return 0;
 }
@@ -138,9 +146,11 @@ int mm_init(void)
  * mm_malloc - Allocate a block by incrementing the brk pointer.
  * Always allocate a block whose size is a multiple of the alignment.
  */
-// 메모리 블록을 할당하는 함수
+// 메모리 블록을 할당하는 함수, size는 payload의 크기
 void *mm_malloc(size_t size)
 {
+    printf("[mm_malloc] 함수 시작, size: %zu\n", size);
+
     size_t asize;      // 조정된 블록 크기
     size_t extendsize; // 필요한 경우 힙을 확장할 크기
     char *bp;
@@ -148,23 +158,22 @@ void *mm_malloc(size_t size)
     // 요청된 크기가 0이면 할당하지 않음
     if (size == 0)
     {
+        printf("[mm_malloc] 함수 종료, ERROR: size == 0\n");
+
         return NULL;
     }
 
     // 블록 크기를 조정 (예: 헤더와 푸터 크기 포함)
-    if (size <= DSIZE)
-    {
-        asize = 2 * DSIZE;
-    }
-    else
-    {
-        asize = DSIZE * ((size + (DSIZE) + (DSIZE - 1)) / DSIZE);
-    }
+    asize = size <= DSIZE
+                ? 2 * DSIZE
+                : DSIZE * ((size + (DSIZE) + (DSIZE - 1)) / DSIZE);
 
     // 적절한 사이즈 클래스에서 블록 탐색
     if ((bp = find_fit(asize)) != NULL)
-    {                     // 적합한 블록 찾음
-        place(bp, asize); // 블록 할당
+    {                                                                            // 적합한 블록 찾음
+        place(bp, asize);                                                        // 블록 할당
+        printf("[mm_malloc] 함수 종료, 할당된 블록 %p, 크기: %zu\n", bp, asize); // 디버깅 로그 추가
+
         return bp;
     }
 
@@ -178,23 +187,33 @@ void *mm_malloc(size_t size)
 
     place(bp, asize); // 블록 할당
 
+    printf("[mm_malloc] 함수 종료, size: %zu\n", size);
+
     return bp;
 }
 
 // mm_free - 사용하지 않을 블록을 해제합니다.
 void mm_free(void *ptr)
 {
+    printf("[mm_free] 함수 시작, ptr: %p\n", ptr);
+
     size_t size = GET_SIZE(HDRP(ptr));
+
+    printf("[mm_free] 해제되는 블록 %p, 크기: %zu\n", ptr, size); // 디버깅 로그 추가
 
     PUT(HDRP(ptr), PACK(size, 0));
     PUT(FTRP(ptr), PACK(size, 0));
 
     coalesce(ptr);
+
+    printf("[mm_free] 함수 종료, ptr: %p\n", ptr);
 }
 
 // mm_realloc - mm_malloc 및 mm_free로 간단하게 구현합니다.
 void *mm_realloc(void *ptr, size_t size)
 {
+    printf("[mm_realloc] 함수 시작, ptr: %p, size: %zu\n", ptr, size);
+
     void *oldptr = ptr;
     void *newptr;
     size_t copySize;
@@ -203,20 +222,27 @@ void *mm_realloc(void *ptr, size_t size)
     newptr = mm_malloc(size);
 
     if (newptr == NULL)
+    {
+        printf("[mm_realloc] 함수 종료, newptr == NULL");
         return NULL;
+    }
 
     // 이전 블록의 데이터 크기를 가져옴
     copySize = GET_SIZE(HDRP(oldptr));
 
     // 실제 복사할 데이터 크기는 이전 블록 크기와 요청된 새 블록 크기 중 작은 값
     if (size < copySize)
+    {
         copySize = size;
+    }
 
     // 데이터를 새 블록으로 복사
     memcpy(newptr, oldptr, copySize);
 
     // 이전 블록 해제
     mm_free(oldptr);
+
+    printf("[mm_realloc] 함수 종료, ptr: %p, size: %zu\n", ptr, size);
 
     return newptr;
 }
@@ -226,20 +252,42 @@ void *mm_realloc(void *ptr, size_t size)
 // 사이즈 클래스별로 분리된 리스트에서 적합한 블록을 찾는 함수
 static void *find_fit(size_t asize)
 {
-    void *bp;
+    printf("[find_fit] 함수 시작, 요청 크기(asize): %zu\n", asize);
 
     // 요청 인덱스로 크기에 맞는 사이즈 클래스를 찾아 해당 클래스부터 탐색 시작
     for (int classIndex = find_class_index(asize); classIndex < MAX_SIZE_CLASS; classIndex++)
     {
-        for (bp = seg_free_list[classIndex]; bp != NULL; bp = GET_NEXT_FREEBLK(bp))
+        printf("[find_fit] 사이즈 클래스 %d 검색 중...\n", classIndex);
+
+        for (void *bp = seg_free_list[classIndex]; bp != NULL; bp = GET_NEXT_FREEBLK(bp))
         {
-            if (asize <= GET_SIZE(HDRP(bp)))
+            // 메모리 접근 전 유효 범위 검사
+            if (bp == NULL || bp < mem_heap_lo() || bp > mem_heap_hi())
             {
+                printf("[find_fit] Error: 메모리 접근 범위를 벗어남 %p\n", bp);
+                break; // 또는 다른 오류 처리
+            }
+
+            if (!GET_ALLOC(HDRP(bp)) && asize <= GET_SIZE(HDRP(bp)))
+            {
+#ifdef DEBUG
+                printf("[find_fit] 적합한 블록 찾음 %p, 크기: %zu\n", bp, GET_SIZE(HDRP(bp)));
+
+                printf("[find_fit] GET(%p): %u\n", bp, GET(bp));
+                printf("[find_fit] GET_SIZE(%p): %zu\n", bp, GET_SIZE(HDRP(bp)));
+                printf("[find_fit] GET_ALLOC(%p): %d\n", bp, GET_ALLOC(HDRP(bp)));
+
+                printf("[find_fit] 함수 종료, 요청 크기(asize): %zu\n", asize);
+#endif
+
                 return bp; // 적합한 블록을 찾았으면 반환
             }
         }
     }
 
+#ifdef DEBUG
+    printf("[find_fit] ERROR: 적합한 블록 찾지 못함\n");
+#endif
     return NULL; // 적합한 블록을 찾지 못함
 }
 
@@ -247,12 +295,19 @@ static void *find_fit(size_t asize)
 // 필요하다면 남은 부분을 분할하여 free list에 추가
 static void place(void *bp, size_t asize)
 {
+    printf("[place] 함수 시작, bp: %p, asize: %zu\n", bp, asize);
+
     size_t csize = GET_SIZE(HDRP(bp)); // 현재 블록의 크기를 알아냄
+
+    printf("[place] 블록 할당 시작 %p, 요청 크기: %zu, 현재 블록 크기: %zu\n", bp, asize, csize);
 
     // 남은 공간이 충분히 클 경우, 즉 요청한 크기(asize)와 현재 크기(csize)의 차이가
     // 두 배의 더블 사이즈(DSIZE)보다 크거나 같으면 블록을 나눔
     if ((csize - asize) >= (2 * DSIZE))
     {
+        printf("[place] 블록 분할 발생, 할당 크기: %zu, 남은 크기: %zu\n", asize, csize - asize);
+
+        // 분할 로직
         PUT(HDRP(bp), PACK(asize, 1));           // 사용할 블록의 헤더에 크기와 할당된 상태 저장
         PUT(FTRP(bp), PACK(asize, 1));           // 사용할 블록의 푸터에도 똑같이 저장
         bp = NEXT_BLKP(bp);                      // 나머지 블록으로 포인터 이동
@@ -262,21 +317,35 @@ static void place(void *bp, size_t asize)
     }
     else // 남은 공간이 충분히 크지 않으면 현재 블록 전체 사용
     {
+        // 전체 블록 사용
+        printf("[place] 전체 블록 사용 %p, 크기: %zu\n", bp, csize);
+
         PUT(HDRP(bp), PACK(csize, 1)); // 현재 블록의 헤더에 크기와 할당된 상태 저장
         PUT(FTRP(bp), PACK(csize, 1)); // 현재 블록의 푸터에도 똑같이 저장
+
+        // 현재 블록을 free list에서 제거
+        remove_block_from_seglist(bp);
     }
+
+    printf("[place] Block %p - size: %zu, allocated: %d\n", bp, GET_SIZE(HDRP(bp)), GET_ALLOC(HDRP(bp)));
+
+    printf("[place] 함수 종료, bp: %p, asize: %zu\n", bp, asize);
 }
 
 static void *extend_heap(size_t words)
 {
+    printf("[extend_heap] 함수 시작, words: %zu\n", words);
+
     char *bp;
-    size_t size;
 
     // 확장할 크기를 정렬 요구 사항에 맞게 조정
-    size = (words % 2) ? (words + 1) * WSIZE : words * WSIZE;
+    size_t size = (words % 2) ? (words + 1) * WSIZE : words * WSIZE;
+
+    printf("[extend_heap] 힙 확장 시작, 요청 워드: %zu, 확장 크기: %zu\n", words, size);
 
     if ((long)(bp = mem_sbrk(size)) == -1)
     {
+        printf("[extend_heap] 함수 종료, 힙 확장 실패\n");
         return NULL;
     }
 
@@ -285,59 +354,140 @@ static void *extend_heap(size_t words)
     PUT(FTRP(bp), PACK(size, 0));         // 프리 블록 푸터
     PUT(HDRP(NEXT_BLKP(bp)), PACK(0, 1)); // 새 에필로그 헤더
 
-    // 인접한 프리 블록과의 병합을 시도하여 메모리 단편화 감소
-    bp = coalesce(bp);
+    if (bp < (char *)mem_heap_lo() || bp > (char *)mem_heap_hi())
+    {
+        printf("[extend_heap] 함수 종료, Error: Block %p is outside heap bounds\n", bp);
+    }
 
-    // 병합된 가용 블록을 적절한 사이즈 클래스의 segregated free list에 추가
-    add_block_to_seglist(bp, size);
+    printf("[extend_heap] 힙 확장 성공, 새 가용 블록 %p, 크기: %zu\n", bp, size);
 
-    return bp;
+    printf("[extend_heap] 함수 종료, words: %zu\n", words);
+
+    // 외부 파편화 때문에 사용
+    return coalesce(bp);
 }
 
 // 인접한 free block을 병합하는 기존 함수를 seglist 방식에 맞게 조정
 // 병합된 블록을 적절한 seglist에 재배치
 static void *coalesce(void *bp)
 {
+    printf("[coalesce] 함수 시작, 적합한 블록 찾지 못함 - bp: %p\n", bp);
+
     size_t prev_alloc = GET_ALLOC(FTRP(PREV_BLKP(bp)));
     size_t next_alloc = GET_ALLOC(HDRP(NEXT_BLKP(bp)));
     size_t size = GET_SIZE(HDRP(bp));
 
-    if (prev_alloc && !next_alloc)
-    { // 다음 블록만 가용
-        remove_block_from_seglist(NEXT_BLKP(bp));
+    for (void *segPtr = seg_free_list; segPtr != NULL; segPtr = GET_NEXT_FREEBLK(segPtr))
+    {
+        printf("[coalesce] Before: Free block %p, next: %p\n", segPtr, GET_NEXT_FREEBLK(segPtr));
+    }
+
+    if (prev_alloc && !next_alloc) // 다음 블록만 가용
+    {
+        printf("[coalesce] 다음 블록이 가용일 때\n");
         size += GET_SIZE(HDRP(NEXT_BLKP(bp)));
+        remove_block_from_seglist(NEXT_BLKP(bp));
         PUT(HDRP(bp), PACK(size, 0));
         PUT(FTRP(bp), PACK(size, 0));
     }
-    else if (!prev_alloc && next_alloc)
-    { // 이전 블록만 가용
-        remove_block_from_seglist(PREV_BLKP(bp));
+    else if (!prev_alloc && next_alloc) // 이전 블록만 가용
+    {
+        printf("[coalesce] 이전 블록이 가용일 때\n");
         size += GET_SIZE(HDRP(PREV_BLKP(bp)));
+        remove_block_from_seglist(PREV_BLKP(bp));
         PUT(FTRP(bp), PACK(size, 0));
         PUT(HDRP(PREV_BLKP(bp)), PACK(size, 0));
         bp = PREV_BLKP(bp);
     }
-    else if (!prev_alloc && !next_alloc)
-    { // 이전과 다음 블록 모두 가용
+    else if (!prev_alloc && !next_alloc) // 이전과 다음 블록 모두 가용
+    {
+        printf("[coalesce] 이전과 다음 블록이 가용일 때\n");
+        size += GET_SIZE(HDRP(PREV_BLKP(bp))) + GET_SIZE(HDRP(NEXT_BLKP(bp)));
         remove_block_from_seglist(PREV_BLKP(bp));
         remove_block_from_seglist(NEXT_BLKP(bp));
-        size += GET_SIZE(HDRP(PREV_BLKP(bp))) + GET_SIZE(HDRP(NEXT_BLKP(bp)));
         PUT(HDRP(PREV_BLKP(bp)), PACK(size, 0));
         PUT(FTRP(NEXT_BLKP(bp)), PACK(size, 0));
         bp = PREV_BLKP(bp);
     }
 
-    // 병합된 블록을 적절한 사이즈 클래스의 리스트에 추가
+    printf("[coalesce] 병합된 블록 %p, 새로운 크기: %zu\n", bp, size); // 디버깅 로그 추가
+
+    // 병합된 블록을 적절한 사이즈 클래스의 리스트에 추가하지만,
+    // 중복을 체크하는 로직은 add_block_to_seglist 함수 내부에서 처리.
+    // 따라서, 여기서는 별도의 중복 체크 로직을 추가하지 않음
+    for (void *segPtr = seg_free_list; segPtr != NULL; segPtr = GET_NEXT_FREEBLK(segPtr))
+    {
+        printf("[coalesce] After: Free block %p, next: %p\n", segPtr, GET_NEXT_FREEBLK(segPtr));
+    }
+
     add_block_to_seglist(bp, size);
+
+    printf("[coalesce] 함수 종료, bp: %p\n", bp);
+
     return bp;
+}
+
+static void verify_list_integrity(void *head)
+{
+    printf("[verify_list_integrity] 함수 시작, head: %p\n", head);
+
+    void *slow = head;
+    void *fast = head;
+
+    // 리스트 순환 검사 (Floyd의 사이클 찾기 알고리즘)
+    while (slow && GET_NEXT_FREEBLK(slow) && fast && GET_NEXT_FREEBLK(fast) && GET_NEXT_FREEBLK(GET_NEXT_FREEBLK(fast)))
+    {
+        slow = GET_NEXT_FREEBLK(slow);
+        fast = GET_NEXT_FREEBLK(GET_NEXT_FREEBLK(fast));
+
+        printf("[verify_list_integrity] slow : %p, fast: %p\n", slow, fast);
+
+        if (slow == fast)
+        {
+            printf("[verify_list_integrity] 함수 종료, ERROR: 순환 참조가 감지되었습니다.\n");
+            return;
+        }
+    }
+
+    // 연결 무결성 검사
+    void *prev = NULL;
+
+    for (void *curr = head; curr != NULL; curr = GET_NEXT_FREEBLK(curr))
+    {
+        if (GET_PREV_FREEBLK(curr) != prev)
+        {
+            printf("[verify_list_integrity] 함수 종료, ERROR: 리스트 연결 무결성 오류가 감지되었습니다. 현재 블록: %p, 이전 블록: %p\n", curr, prev);
+            return;
+        }
+
+        prev = curr;
+    }
+
+    printf("[verify_list_integrity] 함수 종료, head: %p\n", head);
 }
 
 // Free block을 적절한 seglist에 삽입하는 함수. Free 또는 Coalesce 과정에서 사용
 // 메모리 블록을 적절한 사이즈 클래스의 리스트에 추가하는 함수
 static void add_block_to_seglist(void *bp, size_t size)
 {
+    printf("[add_block_to_seglist] 함수 시작, bp: %p, size: %zu\n", bp, size); // 디버깅 로그 추가
+
     // 1. 적절한 사이즈 클래스 찾기
     int class_index = find_class_index(size);
+
+    // 중복 추가 검증 로직
+    for (void *search_bp = seg_free_list[class_index]; search_bp != NULL; search_bp = GET_NEXT_FREEBLK(search_bp))
+    {
+        if (search_bp == bp)
+        {
+            printf("[add_block_to_seglist] 함수 종료, Error: 블록 %p는 이미 사이즈 클래스 %d에 추가되어 있습니다.\n", bp, class_index);
+
+            return; // 이 경우 추가 작업을 중단
+        }
+    }
+
+    // 리스트 무결성 검증 로직 호출
+    verify_list_integrity(seg_free_list[class_index]);
 
     // 2. 현재 블록을 리스트의 첫 번째 위치에 추가
     // 만약 해당 사이즈 클래스에 다른 블록이 이미 있다면, 그 블록을 현재 블록 다음으로 설정
@@ -350,13 +500,41 @@ static void add_block_to_seglist(void *bp, size_t size)
     // 3. 새로운 블록을 리스트의 시작점으로 설정
     seg_free_list[class_index] = bp;
     SET_PREV_FREEBLK(bp, NULL);
+
+    printf("[add_block_to_seglist] 추가된 블록 %p, 크기: %zu, 사이즈 클래스: %d\n", bp, size, class_index); // 디버깅 로그 추가
+
+    printf("[add_block_to_seglist] 함수 종료, bp: %p, size: %zu\n", bp, size); // 디버깅 로그 추가
 }
 
 // Free list에서 특정 블록을 제거하는 함수. 할당 과정에서 사용
 // 메모리 블록을 사이즈 클래스의 리스트에서 제거하는 함수
 static void remove_block_from_seglist(void *bp)
 {
+    printf("[remove_block_from_seglist] 함수 시작, bp: %p\n", bp); // 디버깅 로그 추가
+
     int class_index = find_class_index(GET_SIZE(HDRP(bp)));
+    int found = 0; // 블록이 리스트에 있는지 여부를 추적
+
+    // 리스트에 블록이 실제로 존재하는지 검증
+    for (void *search_bp = seg_free_list[class_index]; search_bp != NULL; search_bp = GET_NEXT_FREEBLK(search_bp))
+    {
+        if (search_bp == bp)
+        {
+            found = 1;
+            break;
+        }
+    }
+
+    if (!found)
+    {
+        printf("[remove_block_from_seglist] 함수 종료, Error: 제거하려는 블록 %p가 사이즈 클래스 %d 리스트에 존재하지 않습니다.\n", bp, class_index);
+        return; // 이 경우 제거 작업을 중단
+    }
+
+#ifdef DEBUG
+    // 리스트 무결성 검증 로직 호출
+    verify_list_integrity(seg_free_list[class_index]);
+#endif
 
     // 만약 이 블록이 리스트의 첫 번째 블록이라면
     if (bp == seg_free_list[class_index])
@@ -374,18 +552,27 @@ static void remove_block_from_seglist(void *bp)
     {
         SET_PREV_FREEBLK(GET_NEXT_FREEBLK(bp), GET_PREV_FREEBLK(bp));
     }
+
+    printf("[remove_block_from_seglist] 제거된 블록 %p\n", bp); // 디버깅 로그 추가
+
+    printf("[remove_block_from_seglist] 함수 종료, bp: %p\n", bp); // 디버깅 로그 추가
 }
 
 // 주어진 크기에 맞는 사이즈 클래스 인덱스를 찾는 함수
 static int find_class_index(size_t size)
 {
+    printf("[find_class_index] 함수 시작, size: %zu\n", size); // 디버깅 로그 추가
+
     for (int i = 0; i < MAX_SIZE_CLASS; i++)
     {
         if (size <= size_classes[i])
         {
-            return i; // 주어진 크기가 현재 사이즈 클래스 범위에 들어오면 인덱스 반환
+            printf("[find_class_index] 함수 종료, index: %d\n", i); // 디버깅 로그 추가
+            return i;                                               // 주어진 크기가 현재 사이즈 클래스 범위에 들어오면 인덱스 반환
         }
     }
+
+    printf("[find_class_index] 함수 종료, MAX_SIZE_CLASS - 1: %d\n", MAX_SIZE_CLASS - 1); // 디버깅 로그 추가
 
     return MAX_SIZE_CLASS - 1; // 가장 큰 사이즈 클래스 반환
 }


### PR DESCRIPTION
현재 아래와 같은 오류가 발생하고 있습니다.

```
Using default tracefiles in ./traces/
ERROR [trace 0, line 7]: Payload (0xf6921820:0xf692184f) overlaps another payload (0xf6921820:0xf6922017)

ERROR [trace 1, line 7]: Payload (0xf6921820:0xf692184f) overlaps another payload (0xf6921820:0xf6922017)

ERROR [trace 2, line 7]: Payload (0xf6921820:0xf692184f) overlaps another payload (0xf6921820:0xf6922017)

ERROR [trace 3, line 7]: Payload (0xf6921820:0xf692184f) overlaps another payload (0xf6921820:0xf6922017)

ERROR [trace 4, line 6]: Payload (0xf6921020:0xf692201e) overlaps another payload (0xf6921020:0xf692201e)

ERROR [trace 5, line 7]: Payload (0xf69225f8:0xf69242bb) overlaps another payload (0xf69225f8:0xf69257a9)

ERROR [trace 6, line 8]: Payload (0xf6921980:0xf6925367) overlaps another payload (0xf6921980:0xf69263f8)

Segmentation fault
```

위의 에러 메세지는 `mdriver.c`의 `add_range` 함수에서 발생하고 있습니다.

제공된 `add_range` 함수 코드를 기반으로, "Payload overlaps another payload" 오류 메시지가 발생하는 원인은 다음과 같을 수 있습니다:

1. **메모리 할당 주소의 중복**: `mm_malloc` 함수 호출을 통해 할당된 메모리 블록의 주소 범위가 다른 블록과 겹치는 경우입니다. 이는 메모리 할당 시스템 내에서 동일한 주소 범위에 여러 번 메모리를 할당하려고 시도할 때 발생할 수 있습니다. 이는 특히 `coalesce`, `place`, 또는 `find_fit` 함수에서 메모리 블록을 적절히 관리하지 못하는 경우에 일어날 수 있습니다.

2. **메모리 해제 및 재할당 문제**: 메모리 블록이 해제된 후 적절히 가용 리스트에 추가되지 않거나, 해제된 블록이 재할당 과정에서 올바르게 처리되지 않아 발생할 수 있습니다. 예를 들어, `mm_free` 함수가 호출된 후 `coalesce`를 통해 병합된 블록이 `seg_free_list`에 올바르게 추가되지 않는 경우 등입니다.

3. **가용 리스트 관리 오류**: `add_block_to_seglist` 및 `remove_block_from_seglist` 함수에서 가용 리스트를 관리하는 로직에 오류가 있어 발생할 수 있습니다. 즉, 가용 블록을 리스트에 추가하거나 제거하는 과정에서 리스트의 무결성이 손상되어, 이미 할당된 블록이 다시 할당되는 문제가 발생할 수 있습니다.

### 해결 방안 제안:

- **디버깅 로그 추가**: 메모리 할당 및 해제 과정에서 각 블록의 주소와 크기를 로그로 출력하여, 어느 시점에 주소가 겹치는 문제가 발생하는지 확인하세요.

- **`add_block_to_seglist` 및 `remove_block_from_seglist` 함수 검토**: 이 함수들에서 가용 블록을 리스트에 추가하거나 제거할 때 리스트의 무결성을 유지하고 있는지 확인하세요. 특히, 블록을 리스트에 추가하거나 제거한 후에 리스트의 모든 블록이 올바르게 연결되어 있는지 검증하세요.

- **`coalesce` 및 `place` 함수의 로직 검증**: 메모리 블록을 병합하거나 분할할 때, 해당 블록들이 올바르게 가용 리스트에 추가되거나 할당되는지 확인하세요. 병합된 블록이 적절한 사이즈 클래스의 리스트에 추가되는지, 분할된 블록이 올바르게 처리되는지 검토가 필요합니다.

- **메모리 할당 및 해제 요청 추적**: 테스트 중에 메모리 할당 및 해제 요청을 추적하여, 오류가 발생하기 직전의 요청을 분석해보세요. 이를 통해 문제의 원인을 좀 더 명확히 파악할 수 있습니다.

위의 점검 사항을 통해 문제의 원인을 좁혀나가며, 코드 내의 버그를 수정해 나가야 합니다. 메모리 관리 시스템의 복잡성 때문에 이러한 종류의 문제를 해결하는 것은 까다로울 수 있으며, 체계적인 접근과 세밀한 검증이 필요합니다.